### PR TITLE
Corrected Module Name: `mExcelNameRules`

### DIFF
--- a/source/mExcelNameRules.bas
+++ b/source/mExcelNameRules.bas
@@ -1,4 +1,4 @@
-Attribute VB_Name = "MExcelNameRules"
+Attribute VB_Name = "mExcelNameRules"
 '
 ' This is free and unencumbered software released into the public domain.
 '


### PR DESCRIPTION
I presume the convention is properly `mExcel*` rather than `MExcel*`, and that this convention applies to the module names (`VB_Name`) along with the filenames (`mExcel*.bas`).